### PR TITLE
Expanded configure options

### DIFF
--- a/build-pgsql.sh
+++ b/build-pgsql.sh
@@ -2,7 +2,24 @@
 
 root=$(pwd)
 cd $root/postgresql-*
-./configure --prefix=/app/vendor --with-openssl  
+LDFLAGS='-Wl,--as-needed -Wl,-z,now' \
+  CFLAGS='-fPIC -DLINUX_OOM_ADJ=0' \
+  ./configure --prefix=/app/vendor/ \
+  --enable-integer-datetimes \
+  --enable-thread-safety \
+  --enable-debug \
+  --disable-rpath \
+  --with-gnu-ld \
+  --with-pgport=5432 \
+  --with-system-tzdata=/usr/share/zoneinfo \
+  --without-tcl \
+  --without-perl \
+  --without-python \
+  --with-krb5 \
+  --with-gssapi \
+  --with-libxml \
+  --with-libxslt \
+  --with-openssl
 make && make install
 rm -rf $root/*
 mv /app/vendor/* $root/


### PR DESCRIPTION
As suggested in http://stackoverflow.com/questions/15725974/setting-postgresql-application-name-on-heroku I have been using these expanded and more explicit configure flags. 
